### PR TITLE
(optimize) fix template loader run twice when webpack frist build in …

### DIFF
--- a/@yurijs/hmr-template-loader/loader.js
+++ b/@yurijs/hmr-template-loader/loader.js
@@ -1,11 +1,17 @@
-const { getRemainingRequest } = require('loader-utils');
-
 module.exports = function loader() {
-  const remaining = '-!' + getRemainingRequest(this);
+  const resourcePath = this.resourcePath;
+
+  const templateLoaderOptions = {
+    defaultNS: '@yurijs/html',
+    styleExtension: '.less',
+    cssModules: true,
+  };
+
+  const templateLoader = `-!@yurijs/template-loader?${JSON.stringify(templateLoaderOptions)}!${resourcePath}`;
 
   if (!this.hot) {
     return `
-    import Component from ${JSON.stringify(remaining)};
+    import Component from ${JSON.stringify(templateLoader)};
     export default Component;
     `;
   }
@@ -13,7 +19,7 @@ module.exports = function loader() {
   import { observable, action } from 'mobx';
   import { observer } from 'mobx-react-lite';
   import { createElement } from 'react';
-  import RawComponent from ${JSON.stringify(remaining)};
+  import RawComponent from ${JSON.stringify(templateLoader)};
 
   var component = observable.box(RawComponent);
 
@@ -23,7 +29,7 @@ module.exports = function loader() {
   })
 
   if (module.hot) {
-    module.hot.accept(${JSON.stringify(remaining)}, action(() => {
+    module.hot.accept(${JSON.stringify(templateLoader)}, action(() => {
       component.set(RawComponent)
     }))
   }

--- a/examples/simple/webpack.config.js
+++ b/examples/simple/webpack.config.js
@@ -40,14 +40,14 @@ module.exports = (_, argv) => {
                 {
                   loader: '@yurijs/hmr-template-loader',
                 },
-                {
-                  loader: '@yurijs/template-loader',
-                  options: {
-                    defaultNS: '@yurijs/html',
-                    styleExtension: '.less',
-                    cssModules: true,
-                  },
-                },
+                // {
+                //   loader: '@yurijs/template-loader',
+                //   options: {
+                //     defaultNS: '@yurijs/html',
+                //     styleExtension: '.less',
+                //     cssModules: true,
+                //   },
+                // },
               ]
             : [
                 {


### PR DESCRIPTION
观察到 dev 环境下初次 build 的时候 template loader 编译了两次，推测是 webpack config 内 template loader 作用了一次， inline 时也作用了一次，很神奇 inline loader 前缀 -!  没有生效...，根据目前情况.. loader context 内的 loaders 长度为 1 判断为 inline loader 时仅作用 template loader..